### PR TITLE
Lock to phpunit 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "psr/http-message": "^1.0",
-        "phpunit/phpunit": ">=6.0",
+        "phpunit/phpunit": "^6.0",
         "helmich/phpunit-json-assert": "^2.0",
         "php": ">=7.0"
     },


### PR DESCRIPTION
 Master isn't currently compatible with phpunit 7 due to method signature changes.

After merging this you should probably tag 2.0.1 from this commit as my next PR will undo this change in order to support 7.0.