### PR TITLE
Make compatible with phpunit 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 sudo: false
 php:
+  - 7.2
   - 7.1
-  - 7.0
 install:
   - composer install --prefer-dist
 script:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library is [MIT-licensed](LICENSE.txt).
 
     $ composer require helmich/phpunit-psr7-assert
 
-**Compatibility notice**: [Version 1](https://github.com/martin-helmich/phpunit-psr7-assert/tree/v1) (the `v1` branch) of this library is compatible with PHPUnit 4.8 to 5. [Version 2](https://github.com/martin-helmich/phpunit-psr7-assert/tree/master) (the `master` branch) is compatible with PHPUnit 6 and later. When using `composer require`, Composer should automatically pick the correct version for you.
+**Compatibility notice**: [Version 1](https://github.com/martin-helmich/phpunit-psr7-assert/tree/v1) (the `v1` branch) of this library is compatible with PHPUnit 4.8 to 5. [Version 2](https://github.com/martin-helmich/phpunit-psr7-assert/tree/v2) (the `v2` branch) is compatible with PHPUnit 6. [Version 3](https://github.com/martin-helmich/phpunit-psr7-assert/tree/master) (the `master` branch) is compatible with PHPUnit 7. When using `composer require`, Composer should automatically pick the correct version for you.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "psr/http-message": "^1.0",
-        "phpunit/phpunit": ">=6.0",
+        "phpunit/phpunit": "^7.0",
         "helmich/phpunit-json-assert": "^2.0",
-        "php": ">=7.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.2",

--- a/src/Constraint/HasStatusConstraint.php
+++ b/src/Constraint/HasStatusConstraint.php
@@ -42,10 +42,10 @@ class HasStatusConstraint extends Constraint
         return $this->status->evaluate($other->getStatusCode(), '', true);
     }
 
-    protected function additionalFailureDescription($other)
+    protected function additionalFailureDescription($other): string
     {
         if ($other instanceof ResponseInterface) {
-            return 'Actual status is ' . $other->getStatusCode() . " and the body contains: " . $other->getBody();
+            return 'Actual status is ' . $other->getStatusCode() . ' and the body contains: ' . $other->getBody();
         }
         return '';
     }


### PR DESCRIPTION
  * Bump phpunit dependency to ^7 - cannot support both 7 and 6 without breaking because of a method override that now has to return `void`.
  * Also bump php version to 7.1
  * This will need tagging as v3 because above
  * Doc change requires creating a v2 branch, should be done after merging #8, or would need #8 merging into it instead of master
 