### PR TITLE
PHP 7.1 uplift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 sudo: false
 php:
+  - 7.2
   - 7.1
-  - 7.0
 install:
   - composer install --prefer-dist
 script:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library is [MIT-licensed](LICENSE.txt).
 
     $ composer require helmich/phpunit-psr7-assert
 
-**Compatibility notice**: [Version 1](https://github.com/martin-helmich/phpunit-psr7-assert/tree/v1) (the `v1` branch) of this library is compatible with PHPUnit 4.8 to 5. [Version 2](https://github.com/martin-helmich/phpunit-psr7-assert/tree/master) (the `master` branch) is compatible with PHPUnit 6 and later. When using `composer require`, Composer should automatically pick the correct version for you.
+**Compatibility notice**: [Version 1](https://github.com/martin-helmich/phpunit-psr7-assert/tree/v1) (the `v1` branch) of this library is compatible with PHPUnit 4.8 to 5. [Version 2](https://github.com/martin-helmich/phpunit-psr7-assert/tree/v2) (the `v2` branch) is compatible with PHPUnit 6. [Version 3](https://github.com/martin-helmich/phpunit-psr7-assert/tree/master) (the `master` branch) is compatible with PHPUnit 7. When using `composer require`, Composer should automatically pick the correct version for you.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "psr/http-message": "^1.0",
-        "phpunit/phpunit": ">=6.0",
+        "phpunit/phpunit": "^7.0",
         "helmich/phpunit-json-assert": "^2.0",
-        "php": ">=7.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.2",

--- a/src/Constraint/BodyMatchesConstraint.php
+++ b/src/Constraint/BodyMatchesConstraint.php
@@ -24,7 +24,7 @@ class BodyMatchesConstraint extends Constraint
      */
     public function toString(): string
     {
-        return "message body matches " . $this->constraint->toString();
+        return 'message body matches ' . $this->constraint->toString();
     }
 
     protected function matches($other): bool

--- a/src/Constraint/HasStatusConstraint.php
+++ b/src/Constraint/HasStatusConstraint.php
@@ -42,10 +42,10 @@ class HasStatusConstraint extends Constraint
         return $this->status->evaluate($other->getStatusCode(), '', true);
     }
 
-    protected function additionalFailureDescription($other)
+    protected function additionalFailureDescription($other): string
     {
         if ($other instanceof ResponseInterface) {
-            return 'Actual status is ' . $other->getStatusCode() . " and the body contains: " . $other->getBody();
+            return 'Actual status is ' . $other->getStatusCode() . ' and the body contains: ' . $other->getBody();
         }
         return '';
     }

--- a/src/Constraint/HasUriConstraint.php
+++ b/src/Constraint/HasUriConstraint.php
@@ -33,6 +33,6 @@ class HasUriConstraint extends Constraint
             return false;
         }
 
-        return $this->uri == $other->getUri()->__toString();
+        return $this->uri === (string) $other->getUri();
     }
 }

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -48,7 +48,7 @@ function hasContentType(string $contentType): Constraint
 {
     return new HasHeaderConstraint(
         'Content-Type',
-        Assert::matchesRegularExpression(',^' . preg_quote($contentType) . '(;.+)?$,')
+        Assert::matchesRegularExpression(',^' . preg_quote($contentType, '/') . '(;.+)?$,')
     );
 }
 

--- a/src/Psr7Assertions.php
+++ b/src/Psr7Assertions.php
@@ -18,72 +18,72 @@ use Psr\Http\Message\ResponseInterface;
 trait Psr7Assertions
 {
 
-    public static function assertRequestHasUri(RequestInterface $request, string $uri)
+    public static function assertRequestHasUri(RequestInterface $request, string $uri): void
     {
         Assert::assertThat($request, static::hasUri($uri));
     }
 
-    public static function assertMessageHasHeader(MessageInterface $message, string $headerName, $headerValue = null)
+    public static function assertMessageHasHeader(MessageInterface $message, string $headerName, $headerValue = null): void
     {
         Assert::assertThat($message, static::hasHeader($headerName, $headerValue));
     }
 
-    public static function assertMessageHasHeaders(MessageInterface $message, array $constraints)
+    public static function assertMessageHasHeaders(MessageInterface $message, array $constraints): void
     {
         Assert::assertThat($message, static::hasHeaders($constraints));
     }
 
-    public static function assertMessageBodyMatches(MessageInterface $message, $constraint)
+    public static function assertMessageBodyMatches(MessageInterface $message, $constraint): void
     {
         Assert::assertThat($message, static::bodyMatches($constraint));
     }
 
-    public static function assertMessageBodyMatchesJson(MessageInterface $message, array $jsonConstraints)
+    public static function assertMessageBodyMatchesJson(MessageInterface $message, array $jsonConstraints): void
     {
         Assert::assertThat($message, static::bodyMatchesJson($jsonConstraints));
     }
 
-    public static function assertResponseHasStatus(ResponseInterface $response, int $status)
+    public static function assertResponseHasStatus(ResponseInterface $response, int $status): void
     {
         Assert::assertThat($response, static::hasStatus($status));
     }
 
-    public static function assertResponseIsSuccess(ResponseInterface $response)
+    public static function assertResponseIsSuccess(ResponseInterface $response): void
     {
         Assert::assertThat($response, static::isSuccess());
     }
 
-    public static function assertResponseIsClientError(ResponseInterface $response)
+    public static function assertResponseIsClientError(ResponseInterface $response): void
     {
         Assert::assertThat($response, static::isClientError());
     }
 
-    public static function assertResponseIsServerError(ResponseInterface $response)
+    public static function assertResponseIsServerError(ResponseInterface $response): void
     {
         Assert::assertThat($response, static::isServerError());
     }
 
-    public static function assertRequestHasMethod(RequestInterface $request, string $method)
+    public static function assertRequestHasMethod(RequestInterface $request, string $method): void
     {
         Assert::assertThat($request, static::hasMethod($method));
     }
 
-    public static function assertRequestIsGet(RequestInterface $request)
+    public static function assertRequestIsGet(RequestInterface $request): void
     {
         Assert::assertThat($request, static::isGet());
     }
 
-    public static function assertRequestIsPost(RequestInterface $request)
+    public static function assertRequestIsPost(RequestInterface $request): void
     {
         Assert::assertThat($request, static::isPost());
     }
 
-    public static function assertRequestIsPut(RequestInterface $request)
+    public static function assertRequestIsPut(RequestInterface $request): void
     {
         Assert::assertThat($request, static::isPut());
     }
 
-    public static function assertRequestIsDelete(RequestInterface $request)
+    public static function assertRequestIsDelete(RequestInterface $request): void
     {
         Assert::assertThat($request, static::isDelete());
     }


### PR DESCRIPTION
  * Use `void` return type where appropriate
  * Address some minor code inspection warnings

Requires #9 first